### PR TITLE
Fix KCIDB results ID uniqueness

### DIFF
--- a/cki-send.py
+++ b/cki-send.py
@@ -70,7 +70,7 @@ def main(args):
                 # When LTP_test is reported, means that the tests failed and we won't get subtests.
                 if test == "LTP_test" and status == "ABORT":
                     extra_data = {
-                        "id": f'redhat:virt_qe_s1.{args.build_id}.{instance_type}.{args.test_os}',
+                        "id": f'{args.kcidb_build_id}.virt_qe_s1.{args.build_id}.{instance_type}.{args.test_os}',
                         "path": "ltp",
                         "comment": "LTP",
                         # KCIDB status cannot be ABORT
@@ -87,7 +87,7 @@ def main(args):
                     total_seconds = int(days or 0) * 86400 + int(hours) * 3600 + int(minutes) * 60 + float(seconds)
 
                     extra_data = {
-                        "id": f'redhat:virt_qe_s1.{args.build_id}.{instance_type}.{args.test_os}.{test}',
+                        "id": f'{args.kcidb_build_id}.virt_qe_s1.{args.build_id}.{instance_type}.{args.test_os}.{test}',
                         "path": f"ltp.{test}",
                         "comment": f"LTP subset {test}",
                         "log_url": console_url,


### PR DESCRIPTION
To make sure the test ids are unique, prepend the cki build id to
the test ids, allowing duplicated jenkins ids across different tested
builds.

In case the tests belong to a build with the following id:

> redhat:12345

The generated tests ids will look like:

> redhat:12345.virt_qe_s1.7.Standard_B2s.rhel-8-1.commands